### PR TITLE
fix upgrade step that was always available

### DIFF
--- a/src/collective/multilingual/profiles/default/metadata.xml
+++ b/src/collective/multilingual/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>1.0</version>
+  <version>1001</version>
 </metadata>

--- a/src/collective/multilingual/upgrades/2.zcml
+++ b/src/collective/multilingual/upgrades/2.zcml
@@ -8,7 +8,7 @@
     provides="Products.GenericSetup.interfaces.EXTENSION" />
 
   <gs:upgradeSteps source="1.0"
-    destination="2"
+    destination="1001"
     profile="collective.multilingual:default">
 
     <gs:upgradeDepends


### PR DESCRIPTION
Fix upgrade step that was available after install of latest. Caused by not updated metadata.xml.
Also change the profile versioning to the standard 100X